### PR TITLE
Add support for direct scene recall

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,18 @@ Clear all effects
     -
         success: {/groups/1/action/effect: none}
 
+Groups also support recalling/loading of scenes. Either using
+
+    $ hueadm group 1 scene=<sceneID>
+    -
+        success: {/groups/1/action/scene: <sceneID>}
+
+or
+
+    $ hueadm recall-scene <sceneID> Garage
+    -
+        success: {/groups/1/action/scene: <sceneID>}
+
 #### Delete a group
 
 To delete the group run
@@ -598,6 +610,7 @@ Usage
         create-scene    Create a scene
         modify-scene    Modify a scene
         delete-scene    Delete a scene
+        recall-scene    Recalls a scene
 
       Sensors:
         sensors         List all sensors

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -92,6 +92,7 @@ function CLI() {
             'create-scene',
             'modify-scene',
             'delete-scene',
+            'recall-scene',
             { group: 'Sensors' },
             'sensors',
             'sensor',
@@ -238,6 +239,7 @@ CLI.prototype.do_scene = require('./commands/scene');
 CLI.prototype.do_create_scene = require('./commands/create-scene');
 CLI.prototype.do_modify_scene = require('./commands/modify-scene');
 CLI.prototype.do_delete_scene = require('./commands/delete-scene');
+CLI.prototype.do_recall_scene = require('./commands/recall-scene');
 
 CLI.prototype.do_sensors = require('./commands/sensors');
 CLI.prototype.do_sensor = require('./commands/sensor');

--- a/lib/commands/light.js
+++ b/lib/commands/light.js
@@ -24,6 +24,12 @@ function light(subcmd, opts, args, cb) {
         return;
     }
 
+    if (args[0].match(/^\bscene=\b(.*)$/))
+    {
+        cb(new Error('Cannot recall a scene for a single light.'));
+        return;
+    }
+
     // create a light state object
     var state = common.createLightState(args);
     if (state instanceof Error) {

--- a/lib/commands/recall-scene.js
+++ b/lib/commands/recall-scene.js
@@ -1,0 +1,43 @@
+var common = require('../common');
+
+module.exports = recallScene;
+
+function recallScene(subcmd, opts, args, cb) {
+    var self = this;
+
+    var finish = common.makeFinisher(opts, cb);
+
+    if (opts.help) {
+        self.do_help('help', {}, [subcmd], cb);
+        return;
+    }
+
+    var sceneId = args.shift();
+
+    if (!sceneId) {
+        cb(new Error('Scene ID is required.'));
+        return;
+    }
+
+    var groupId = args.shift();
+
+    if (!groupId) {
+        cb(new Error('Group ID is required'))
+    }
+
+    self.do_group('group', opts, [groupId, 'scene='+sceneId], cb)
+}
+
+recallScene.options = [
+    {
+        names: ['help', 'h'],
+        type: 'bool',
+        help: 'Show this help.'
+    },
+    {
+        names: ['json', 'j'],
+        type: 'bool',
+        help: 'JSON output.'
+    }
+];
+recallScene.help = 'Recalls a scene on a group\nUSAGE: hueadm recall-scene SCENEID GROUPID\n\n{{options}}';

--- a/lib/common.js
+++ b/lib/common.js
@@ -275,6 +275,10 @@ function createLightState(args) {
         var kelvin = +match[1];
         var ct = mired.kelvinToMired(kelvin);
         state.ct = Math.round(ct);
+    }
+    else if ((match = command.match(/^\bscene=\b(.*)$/))) {
+        var sceneId = match[1];
+        state = { "scene": sceneId };
     } else {
         var hex = csscolors[command];
 


### PR DESCRIPTION
This change adds support for directly recalling scenes. It surfaces two means of doing so:
1. As a state change on a group: `hueadm group <group> scene=<sceneID>`
2. As a scene subcommand: `hueadm recall-scene <sceneID> <group>`