### PR TITLE
Docker build pipeline

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,25 +42,25 @@ jobs:
         password: ${{ secrets.GHCRIO_PAT }}
         logout: true
       
-#    - name: Build an Publish Image
-#      id: docker_build
-#      uses: docker/build-push-action@v2
-#      with:
-#        push: true
-#        tags: |
-#          mmuffins/hueadm:latest
-#          mmuffins/hueadm:${{ steps.prep.outputs.nodePackageVer }}
-#          ghcr.io/mmuffins/hueadm:latest
-#          ghcr.io/mmuffins/hueadm:${{ steps.prep.outputs.nodePackageVer }}
-#        context: ${{ GITHUB.WORKSPACE }}
-#        file: docker/Dockerfile
-#        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
-#        labels: |
-#          org.opencontainers.image.title=${{ github.event.repository.name }}
-#          org.opencontainers.image.description=${{ github.event.repository.description }}
-#          org.opencontainers.image.url=${{ github.event.repository.html_url }}
-#          org.opencontainers.image.source=${{ github.event.repository.clone_url }}
-#          org.opencontainers.image.revision=${{ github.sha }}
-#          org.opencontainers.image.created=${{ steps.prep.outputs.created }}
-#          org.opencontainers.image.version=${{ steps.prep.outputs.nodePackageVer }}
-#          org.opencontainers.image.licenses='MIT'
+    - name: Build an Publish Image
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        push: true
+        tags: |
+          mmuffins/hueadm:latest
+          mmuffins/hueadm:${{ steps.prep.outputs.nodePackageVer }}
+          ghcr.io/mmuffins/hueadm:latest
+          ghcr.io/mmuffins/hueadm:${{ steps.prep.outputs.nodePackageVer }}
+        context: ${{ GITHUB.WORKSPACE }}
+        file: docker/Dockerfile
+        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
+        labels: |
+          org.opencontainers.image.title=${{ github.event.repository.name }}
+          org.opencontainers.image.description=${{ github.event.repository.description }}
+          org.opencontainers.image.url=${{ github.event.repository.html_url }}
+          org.opencontainers.image.source=${{ github.event.repository.clone_url }}
+          org.opencontainers.image.revision=${{ github.sha }}
+          org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+          org.opencontainers.image.version=${{ steps.prep.outputs.nodePackageVer }}
+          org.opencontainers.image.licenses='MIT'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,66 @@
+name: docker-push
+
+on:
+  workflow_dispatch:
+
+env:
+ imageName: hueadm
+
+jobs:
+
+  build:
+    name: Build and Publish Docker Image
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      
+    - name: Set Docker Labels
+      id: prep
+      run: |
+        echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+        echo ::set-output name=labelref::$(date +%s)
+        echo ::set-output name=nodePackageVer::$(npm view hueadm dist-tags.latest)
+        
+    - name: Docker Setup QEMU
+      uses: docker/setup-qemu-action@v1
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+      
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }} 
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        logout: true
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ GITHUB.ACTOR }}
+        password: ${{ secrets.GHCRIO_PAT }}
+        logout: true
+      
+#    - name: Build an Publish Image
+#      id: docker_build
+#      uses: docker/build-push-action@v2
+#      with:
+#        push: true
+#        tags: |
+#          mmuffins/hueadm:latest
+#          mmuffins/hueadm:${{ steps.prep.outputs.nodePackageVer }}
+#          ghcr.io/mmuffins/hueadm:latest
+#          ghcr.io/mmuffins/hueadm:${{ steps.prep.outputs.nodePackageVer }}
+#        context: ${{ GITHUB.WORKSPACE }}
+#        file: docker/Dockerfile
+#        platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
+#        labels: |
+#          org.opencontainers.image.title=${{ github.event.repository.name }}
+#          org.opencontainers.image.description=${{ github.event.repository.description }}
+#          org.opencontainers.image.url=${{ github.event.repository.html_url }}
+#          org.opencontainers.image.source=${{ github.event.repository.clone_url }}
+#          org.opencontainers.image.revision=${{ github.sha }}
+#          org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+#          org.opencontainers.image.version=${{ steps.prep.outputs.nodePackageVer }}
+#          org.opencontainers.image.licenses='MIT'

--- a/README.md
+++ b/README.md
@@ -5,12 +5,18 @@ A command line management interface to [phillips hue](http://meethue.com)
 
 Installation
 ------------
+### Locally
 
 First, install [Node.js](http://nodejs.org), then:
 
     npm install -g hueadm
 
 ...and the executable will be installed globally as `hueadm`
+
+### With Docker
+After setting up docker [docker](https://docs.docker.com/get-docker/), run:
+
+    docker pull mmuffins/hueadm:latest
 
 Getting Started
 ---------------
@@ -85,6 +91,42 @@ for `hueadm` to use if those arguments are not specified.
         "user": "f28jfl3gtltQw4r4gKLEtVFsfJcBGE87A1RaAXgt",
         "host": "10.0.1.80"
     }
+
+### Docker Setup
+
+#### Invoking Commands
+Once the image has been pulled, all functions of the cli are avalable by passing the needed parameters to a new container
+
+    $ docker run --rm mmuffins/hueadm -H 10.0.1.80 -U f28jfl3gtltQw4r4gKLEtVFsfJcBGE87A1RaAXgt lights
+    ID  NAME                       STATUS  BRIGHTNESS  REACHABLE
+    1   Nightstand                 on      254         true
+    2   Garage Right               on      254         false
+    ... snipped ...
+
+#### Using a Config File
+It is possible to provide a config file by mounting it as volume
+
+    $ vim ~/.hueadm.json
+    $ cat ~/.hueadm.json
+    {
+        "user": "f28jfl3gtltQw4r4gKLEtVFsfJcBGE87A1RaAXgt",
+        "host": "10.0.1.80"
+    }
+    $ docker run --rm --mount type=bind,source=${HOME}/.hueadm.json,target=/hueadm.json mmuffins/hueadm -c /hueadm.json lights
+    ID  NAME                       STATUS  BRIGHTNESS  REACHABLE
+    1   Nightstand                 on      254         true
+    2   Garage Right               on      254         false
+    ... snipped ...
+
+#### Using aliases
+To simplify the usage of the image, an alias can be set
+
+    $ alias hueadm="docker run --rm -H 10.0.1.80 -U f28jfl3gtltQw4r4gKLEtVFsfJcBGE87A1RaAXgt"
+    $ hueadm lights
+    ID  NAME                       STATUS  BRIGHTNESS  REACHABLE
+    1   Nightstand                 on      254         true
+    2   Garage Right               on      254         false
+    ... snipped ...
 
 ### Lights
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,3 @@
+FROM node:lts-alpine3.11
+RUN npm install hueadm -g
+ENTRYPOINT ["hueadm"]


### PR DESCRIPTION
This PR contains a pipeline which

- spins up a github hosted build agent and sets up a couple of prerequisites
- pulls the latest version of hueadm from npm
- creates a new docker container from it
- pushes the container to dockerhub and the github container registry

The new docker container will take its version from the downloaded npm package, so to avoid version conflicts it should probably not be executed before a new version is pushed to npam.

I set the action to run on event_dispatch, meaning that it can be triggered manually in the Actions tab of the repository. We can also set it to run automatically, but since there hasn't been that much activity on the repo (and I don't figure that phillips will do major changes on their API anytime soon) I left it at that.