### PR TITLE
Allow 'light' command to specify light by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,11 @@ To get information about a specific light:
     uniqueid: 'removed'
     swversion: 5.50.1.19085
 
+Lights can also be identified by name, as long as the name is unique:
+
+    $ hueadm light "Test Light 1"
+    [same output as above]
+
 All subcommands allow for `-j` or `--json` to be specified to force the output
 to be JSON.
 
@@ -171,7 +176,7 @@ Turn a light on or off
     $ hueadm light 15 off
     -
         success: {/lights/15/state/on: false}
-    $ hueadm light 15 on
+    $ hueadm light "Test Light 1" on
     -
         success: {/lights/15/state/on: true}
 

--- a/lib/commands/light.js
+++ b/lib/commands/light.js
@@ -11,35 +11,75 @@ function light(subcmd, opts, args, cb) {
         return;
     }
 
-    var id = parseInt(args.shift(), 10);
-
-    if (isNaN(id)) {
-        cb(new Error('first argument must be a number'));
+    var arg = args.shift();
+    if (arg === undefined) {
+        finish(new Error('light name or id must be supplied'));
         return;
     }
 
-    // get light information only
-    if (args.length === 0) {
-        self.client.light(id, finish);
+    var id = parseInt(arg, 10);
+    if (!isNaN(id)) {
+        doLight(id);
         return;
     }
 
-    if (args[0].match(/^\bscene=\b(.*)$/))
-    {
-        cb(new Error('Cannot recall a scene for a single light.'));
-        return;
+    // we have a light name, try to resolve it.
+    self.client.lights(function (err, data) {
+        if (err) {
+            finish(err);
+            return;
+        }
+
+        // data is in the form of id => data
+        // ex: {
+        //  1: {
+        //    ..
+        //  },
+        var idMap = {};
+        var matchingLights = Object.keys(data).map(function (id) {
+            idMap[data[id].name] = id;
+            return data[id];
+        }).filter(function (light) {
+            return light.name === arg;
+        });
+
+        switch (matchingLights.length) {
+        case 0:
+            finish(new Error(f('No light "%s" found', arg)));
+            break;
+        case 1:
+            doLight(idMap[matchingLights[0].name]);
+            break;
+        default:
+            finish(new Error(f('Multiple lights "%s" found', arg)));
+            break;
+        }
+    });
+
+    function doLight(id) {
+        // get light information only
+        if (args.length === 0) {
+            self.client.light(id, finish);
+            return;
+        }
+
+        if (args[0].match(/^\bscene=\b(.*)$/))
+        {
+            cb(new Error('Cannot recall a scene for a single light.'));
+            return;
+        }
+
+        // create a light state object
+        var state = common.createLightState(args);
+        if (state instanceof Error) {
+            cb(state);
+            return;
+        }
+
+        self.debug('setLightState(%d, %j)', id, state);
+
+        self.client.setLightState(id, state, finish);
     }
-
-    // create a light state object
-    var state = common.createLightState(args);
-    if (state instanceof Error) {
-        cb(state);
-        return;
-    }
-
-    self.debug('setLightState(%d, %j)', id, state);
-
-    self.client.setLightState(id, state, finish);
 }
 
 light.options = [


### PR DESCRIPTION
It was bothering me that I could specify a group by name or ID, but an individual light only by ID.

The code for this is essentially a copy-and-paste from the `group` command.