### PR TITLE
Add Toggle functionality to Lights and Groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ different ways to change the state of the lights.
 
 - `on`: turn the light on
 - `off`: turn the light off
+- `toggle`: toggle the current on/of state of a light
 - `clear`: clear any and all effects on a light
 - `reset`: clear any and all effects on a light and set it to the "default" color (as if it just turned on)
 - `select`: flash the light once

--- a/lib/commands/group.js
+++ b/lib/commands/group.js
@@ -59,15 +59,29 @@ function group(subcmd, opts, args, cb) {
         }
     });
 
-    function doGroup(id) {
+    async function doGroup(id) {
         // get group information only
         if (args.length === 0) {
             self.client.group(id, finish);
             return;
         }
 
+        var state = null;
+
+        if (args[0] == 'toggle') {
+            // Toggle is not a native api option. So we need to get the current state based on any_on.
+            await new Promise((resolve, reject) => {
+                self.client.group(id, function(err, result) {
+                    if (err) return reject(err);
+                    console.log(result);
+                    state = {on: result.state.any_on};
+                    resolve();
+                });
+            });
+        }
+
         // create a light state object
-        var state = common.createLightState(args);
+        var state = common.createLightState(args, state);
         if (state instanceof Error) {
             cb(state);
             return;

--- a/lib/commands/light.js
+++ b/lib/commands/light.js
@@ -56,7 +56,7 @@ function light(subcmd, opts, args, cb) {
         }
     });
 
-    function doLight(id) {
+    async function doLight(id) {
         // get light information only
         if (args.length === 0) {
             self.client.light(id, finish);
@@ -69,8 +69,21 @@ function light(subcmd, opts, args, cb) {
             return;
         }
 
+        var state = null;
+
+        if (args[0] == 'toggle') {
+            // Toggle is not a native api option. So we need to get the current state.
+            await new Promise((resolve, reject) => {
+                self.client.light(id, function(err, result) {
+                    if (err) return reject(err);
+                    state = {on: result.state.on};
+                    resolve();
+                });
+            });
+        }
+
         // create a light state object
-        var state = common.createLightState(args);
+        var state = common.createLightState(args, state);
         if (state instanceof Error) {
             cb(state);
             return;

--- a/lib/common.js
+++ b/lib/common.js
@@ -222,9 +222,9 @@ function hex2rgb(hex) {
 }
 
 // create a light state object with opts
-function createLightState(args) {
-    // create a light state object
-    var state = {
+function createLightState(args, state = null) {
+    // create a light state object if it isn't provided
+    state = state ?? {
         on: true
     };
 
@@ -235,6 +235,8 @@ function createLightState(args) {
         state.on = true;
     } else if (command === 'off') {
         state.on = false;
+    } else if (command === 'toggle') {
+        state.on = !state.on
     } else if (command === 'clear') {
         state.alert = 'none';
         state.effect = 'none';


### PR DESCRIPTION
# Description:

With the current implementation, users are limited to specifically setting their lights and groups to either `on` or `off`. While these commands are straightforward and intuitive, there are scenarios where users may want to quickly switch the current state without first checking it.

To enhance the user experience and provide more flexible command options, this Pull Request introduces the `toggle` functionality for both lights and groups. This new feature fetches the current state of the light or group and switches it to the opposite state (from `on` to `off` or vice versa).

## New Commands:

Users can now utilize the following commands to toggle the state of their lights and groups:

```
hueadm light <id> toggle
hued group <id> toggle
```

- **Convenience:** Users no longer need to know the current state of their light or group to change it.
- **Efficiency:** Enables quick switching, especially useful in automation scripts or frequent use cases.